### PR TITLE
Add basic WordPress settings plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,20 @@
-# wpplugin
+# Simple Setting Plugin
+
+This repository contains a minimal WordPress plugin demonstrating a basic MVC structure using OOP.
+
+## Installation
+1. Copy the `simple-setting-plugin` folder into your WordPress `wp-content/plugins` directory.
+2. Activate **Simple Setting Plugin** from the WordPress admin.
+3. Navigate to **Settings → Simple Setting** to modify the example setting.
+
+## Structure
+```
+simple-setting-plugin/
+├── simple-setting-plugin.php  # Plugin bootstrap
+├── controllers/
+│   └── SettingsController.php
+├── models/
+│   └── SettingsModel.php
+└── views/
+    └── settings-form.php
+```

--- a/simple-setting-plugin/controllers/SettingsController.php
+++ b/simple-setting-plugin/controllers/SettingsController.php
@@ -1,0 +1,35 @@
+<?php
+
+require_once plugin_dir_path(__FILE__) . '../models/SettingsModel.php';
+
+class SettingsController {
+    private $model;
+
+    public function __construct() {
+        $this->model = new SettingsModel();
+    }
+
+    public function init_hooks() {
+        add_action('admin_menu', [$this, 'add_menu']);
+        add_action('admin_init', [$this, 'register_settings']);
+    }
+
+    public function add_menu() {
+        add_options_page(
+            'Simple Setting Plugin',
+            'Simple Setting',
+            'manage_options',
+            'simple-setting-plugin',
+            [$this, 'render_settings_page']
+        );
+    }
+
+    public function register_settings() {
+        register_setting('ssp_options_group', 'ssp_option');
+    }
+
+    public function render_settings_page() {
+        $value = $this->model->get_option();
+        include plugin_dir_path(__FILE__) . '../views/settings-form.php';
+    }
+}

--- a/simple-setting-plugin/models/SettingsModel.php
+++ b/simple-setting-plugin/models/SettingsModel.php
@@ -1,0 +1,13 @@
+<?php
+
+class SettingsModel {
+    private $option_name = 'ssp_option';
+
+    public function get_option() {
+        return get_option($this->option_name, '');
+    }
+
+    public function save_option($value) {
+        update_option($this->option_name, sanitize_text_field($value));
+    }
+}

--- a/simple-setting-plugin/simple-setting-plugin.php
+++ b/simple-setting-plugin/simple-setting-plugin.php
@@ -1,0 +1,23 @@
+<?php
+/*
+Plugin Name: Simple Setting Plugin
+Description: A basic plugin demonstrating MVC structure to save a setting in WordPress.
+Version: 1.0.0
+Author: Codex
+*/
+
+if (!defined('ABSPATH')) {
+    exit; // Exit if accessed directly.
+}
+
+require_once plugin_dir_path(__FILE__) . 'models/SettingsModel.php';
+require_once plugin_dir_path(__FILE__) . 'controllers/SettingsController.php';
+
+class Simple_Setting_Plugin {
+    public function __construct() {
+        $controller = new SettingsController();
+        $controller->init_hooks();
+    }
+}
+
+new Simple_Setting_Plugin();

--- a/simple-setting-plugin/views/settings-form.php
+++ b/simple-setting-plugin/views/settings-form.php
@@ -1,0 +1,15 @@
+<div class="wrap">
+    <h1>Simple Setting Plugin</h1>
+    <form method="post" action="options.php">
+        <?php settings_fields('ssp_options_group'); ?>
+        <?php do_settings_sections('ssp_options_group'); ?>
+        <table class="form-table">
+            <tr valign="top">
+                <th scope="row">Example Setting</th>
+                <td><input type="text" name="ssp_option" value="<?php echo esc_attr($value); ?>" /></td>
+            </tr>
+        </table>
+        <?php submit_button(); ?>
+    </form>
+</div>
+


### PR DESCRIPTION
## Summary
- create `simple-setting-plugin` with MVC structure
- implement `SettingsModel`, `SettingsController`, and view template
- bootstrap the plugin in `simple-setting-plugin.php`
- update README with instructions

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_682daa0a0748832cb69776c2ccab3002